### PR TITLE
Port to Minecraft 26.1.2 (Fabric, Mojang mappings, Java 25)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [ 21 ]
+        java: [ 25 ]
         os: [ ubuntu-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version "${loom_version}"
+    id 'net.fabricmc.fabric-loom' version "${loom_version}"
     id 'maven-publish'
 }
 
@@ -15,15 +15,20 @@ repositories {
 
 loom {
     accessWidenerPath = file("src/main/resources/auto-reauth.accesswidener")
+
+    mods {
+        "auto-reauth" {
+            sourceSet sourceSets.main
+        }
+    }
 }
 
 dependencies {
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
-    mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
 
-    modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
-    modImplementation "com.terraformersmc:modmenu:${project.mod_menu_version}"
-    modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+    implementation "net.fabricmc:fabric-loader:${project.loader_version}"
+    implementation "com.terraformersmc:modmenu:${project.mod_menu_version}"
+    implementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 }
 
 processResources {
@@ -39,7 +44,7 @@ processResources {
     }
 }
 
-def targetJavaVersion = 21
+def targetJavaVersion = 25
 tasks.withType(JavaCompile).configureEach {
     // ensure that the encoding is set to UTF-8, no matter what the system default is
     // this fixes some edge cases with special characters not displaying correctly
@@ -57,8 +62,8 @@ java {
     // If you remove this line, sources will not be generated.
     withSourcesJar()
 
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
+    sourceCompatibility = JavaVersion.VERSION_25
+    targetCompatibility = JavaVersion.VERSION_25
 }
 
 jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,10 +2,9 @@
 org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
-minecraft_version=1.21.11
-yarn_mappings=1.21.11+build.3
-loader_version=0.18.4
-loom_version=1.14-SNAPSHOT
+minecraft_version=26.1.2
+loader_version=0.19.2
+loom_version=1.16-SNAPSHOT
 
 # Mod Properties
 mod_version = 0.4.0
@@ -13,5 +12,5 @@ maven_group = com.connorcode
 archives_base_name = auto-reauth
 
 # Dependencies
-fabric_version=0.140.2+1.21.11
-mod_menu_version=17.0.0-beta.1
+fabric_version=0.146.1+26.1.2
+mod_menu_version=18.0.0-alpha.8

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/com/connorcode/autoreauth/Commands.java
+++ b/src/main/java/com/connorcode/autoreauth/Commands.java
@@ -3,33 +3,32 @@ package com.connorcode.autoreauth;
 import com.connorcode.autoreauth.auth.AuthUtils;
 import com.mojang.authlib.exceptions.AuthenticationException;
 import com.mojang.brigadier.CommandDispatcher;
-import net.fabricmc.fabric.api.client.command.v2.ClientCommandManager;
+import net.fabricmc.fabric.api.client.command.v2.ClientCommands;
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
-import net.minecraft.client.session.Session;
-import net.minecraft.command.CommandRegistryAccess;
-import net.minecraft.network.packet.s2c.common.DisconnectS2CPacket;
-import net.minecraft.text.Text;
-
+import net.minecraft.client.User;
+import net.minecraft.commands.CommandBuildContext;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.protocol.common.ClientboundDisconnectPacket;
 import java.util.Objects;
 
 import static com.connorcode.autoreauth.Main.client;
 import static com.connorcode.autoreauth.Main.config;
 
 public class Commands {
-    public static void register(CommandDispatcher<FabricClientCommandSource> dispatcher, CommandRegistryAccess registryAccess) {
-        dispatcher.register(ClientCommandManager.literal("auto-reauth").requires(requirement -> config.debug)
-                .then(ClientCommandManager.literal("invalidate").executes(context -> {
-                    var session = client.getSession();
-                    var newSession = new Session(session.getUsername(), session.getUuidOrNull(), "", session.getXuid(), session.getClientId());
+    public static void register(CommandDispatcher<FabricClientCommandSource> dispatcher, CommandBuildContext registryAccess) {
+        dispatcher.register(ClientCommands.literal("auto-reauth").requires(requirement -> config.debug)
+                .then(ClientCommands.literal("invalidate").executes(context -> {
+                    var session = client.getUser();
+                    var newSession = new User(session.getName(), session.getProfileId(), "", session.getXuid(), session.getClientId());
                     try {
                         AuthUtils.setSession(newSession);
                     } catch (AuthenticationException e) {
                         // ignored
                     }
-                    context.getSource().sendFeedback(Text.of("Session invalidated"));
+                    context.getSource().sendFeedback(Component.nullToEmpty("Session invalidated"));
                     return 1;
-                })).then(ClientCommandManager.literal("kick").executes(context -> {
-                    Objects.requireNonNull(client.player).networkHandler.onDisconnect(new DisconnectS2CPacket(Text.translatable("disconnect.kicked")));
+                })).then(ClientCommands.literal("kick").executes(context -> {
+                    Objects.requireNonNull(client.player).connection.handleDisconnect(new ClientboundDisconnectPacket(Component.translatable("disconnect.kicked")));
                     return 1;
                 })));
     }

--- a/src/main/java/com/connorcode/autoreauth/Config.java
+++ b/src/main/java/com/connorcode/autoreauth/Config.java
@@ -1,11 +1,10 @@
 package com.connorcode.autoreauth;
 
 import com.connorcode.autoreauth.auth.MicrosoftAuth;
-import net.minecraft.client.session.Session;
-import net.minecraft.nbt.NbtCompound;
+import net.minecraft.client.User;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.NbtIo;
-import net.minecraft.nbt.NbtList;
-
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -64,7 +63,7 @@ public class Config {
 
             this.debug = tag.getBoolean("debug").orElse(false);
             this.auto = tag.getBoolean("auto").orElse(true);
-            this.accounts = tag.getList("accounts").orElse(new NbtList()).stream()
+            this.accounts = tag.getList("accounts").orElse(new ListTag()).stream()
                     .map(account -> new Account(account.asCompound().orElseThrow()))
                     .collect(ArrayList::new, ArrayList::add, ArrayList::addAll);
 
@@ -78,12 +77,12 @@ public class Config {
     }
 
     public void save() {
-        var tag = new NbtCompound();
+        var tag = new CompoundTag();
         tag.putBoolean("debug", debug);
         tag.putBoolean("auto", auto);
         tag.putInt("default", accounts.indexOf(defaultAccount));
 
-        var accounts = new NbtList();
+        var accounts = new ListTag();
         for (var account : this.accounts)
             accounts.add(account.serialize());
 
@@ -98,18 +97,18 @@ public class Config {
     }
 
     public record Account(MicrosoftAuth.AccessToken accessToken, UUID uuid, String username) {
-        public Account(MicrosoftAuth.AccessToken access, Session session) {
-            this(access, session.getUuidOrNull(), session.getUsername());
+        public Account(MicrosoftAuth.AccessToken access, User session) {
+            this(access, session.getProfileId(), session.getName());
         }
 
-        public Account(NbtCompound nbt) {
+        public Account(CompoundTag nbt) {
             this(new MicrosoftAuth.AccessToken(nbt.getString("accessToken").orElseThrow(), nbt.getString("refreshToken")
                     .orElseThrow()), Misc.parseUUID(nbt.getString("uuid").orElseThrow()), nbt.getString("username")
                     .orElseThrow());
         }
 
-        public NbtCompound serialize() {
-            var tag = new NbtCompound();
+        public CompoundTag serialize() {
+            var tag = new CompoundTag();
             tag.putString("accessToken", accessToken.accessToken());
             tag.putString("refreshToken", accessToken.refreshToken());
             tag.putString("uuid", uuid.toString());

--- a/src/main/java/com/connorcode/autoreauth/Main.java
+++ b/src/main/java/com/connorcode/autoreauth/Main.java
@@ -4,7 +4,7 @@ import com.connorcode.autoreauth.auth.AuthUtils;
 import com.mojang.logging.LogUtils;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
-import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.Minecraft;
 import org.slf4j.Logger;
 
 import java.nio.file.Path;
@@ -13,7 +13,7 @@ import java.util.concurrent.CompletableFuture;
 public class Main implements ClientModInitializer {
     public static final Path directory = Path.of(System.getProperty("user.home")).resolve(".auto-reauth");
     public static Logger log = LogUtils.getLogger();
-    public static MinecraftClient client = MinecraftClient.getInstance();
+    public static Minecraft client = Minecraft.getInstance();
 
     public static Config config = new Config();
     public static CompletableFuture<AuthUtils.AuthStatus> authStatus;

--- a/src/main/java/com/connorcode/autoreauth/Misc.java
+++ b/src/main/java/com/connorcode/autoreauth/Misc.java
@@ -1,10 +1,9 @@
 package com.connorcode.autoreauth;
 
-import net.minecraft.client.toast.SystemToast;
-import net.minecraft.text.Text;
-
 import java.math.BigInteger;
 import java.util.UUID;
+import net.minecraft.client.gui.components.toasts.SystemToast;
+import net.minecraft.network.chat.Component;
 
 import static com.connorcode.autoreauth.Main.client;
 
@@ -18,8 +17,8 @@ public class Misc {
     }
 
     public static void sendToast(String title, String message) {
-        client.send(() -> client.getToastManager()
-                .add(new SystemToast(SystemToast.Type.PERIODIC_NOTIFICATION, Text.of(title), Text.of(message))));
+        client.schedule(() -> client.getToastManager()
+                .addToast(new SystemToast(SystemToast.SystemToastId.PERIODIC_NOTIFICATION, Component.nullToEmpty(title), Component.nullToEmpty(message))));
 
     }
 

--- a/src/main/java/com/connorcode/autoreauth/Reauth.java
+++ b/src/main/java/com/connorcode/autoreauth/Reauth.java
@@ -4,15 +4,14 @@ import com.connorcode.autoreauth.auth.AuthUtils;
 import com.connorcode.autoreauth.auth.MicrosoftAuth;
 import com.connorcode.autoreauth.gui.ErrorScreen;
 import com.mojang.authlib.exceptions.AuthenticationException;
+import com.mojang.blaze3d.platform.cursor.CursorTypes;
 import net.fabricmc.loader.api.FabricLoader;
-import net.minecraft.client.gui.DrawContext;
-import net.minecraft.client.gui.cursor.StandardCursors;
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.gui.screen.multiplayer.MultiplayerScreen;
-import net.minecraft.client.util.math.Rect2i;
-import net.minecraft.text.Text;
-import net.minecraft.util.Formatting;
-
+import net.minecraft.ChatFormatting;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.gui.screens.multiplayer.JoinMultiplayerScreen;
+import net.minecraft.client.renderer.Rect2i;
+import net.minecraft.network.chat.Component;
 import java.util.concurrent.CompletableFuture;
 
 import static com.connorcode.autoreauth.Main.*;
@@ -20,30 +19,30 @@ import static com.connorcode.autoreauth.Main.*;
 public class Reauth {
     static final boolean METEOR_LOADED = FabricLoader.getInstance().isModLoaded("meteor-client");
 
-    public static boolean renderAuthStatus(DrawContext context, int mouseX, int mouseY) {
+    public static boolean renderAuthStatus(GuiGraphicsExtractor context, int mouseX, int mouseY) {
         var status = authStatus.getNow(AuthUtils.AuthStatus.Unknown);
         var color = switch (status) {
-            case Unknown -> Formatting.GRAY;
-            case Invalid, Offline -> Formatting.RED;
-            case Online -> Formatting.GREEN;
+            case Unknown -> ChatFormatting.GRAY;
+            case Invalid, Offline -> ChatFormatting.RED;
+            case Online -> ChatFormatting.GREEN;
         };
 
-        var txt = client.textRenderer;
-        if (METEOR_LOADED && client.currentScreen instanceof MultiplayerScreen) {
-            var text = Text.literal("[ ").append(Text.literal(String.valueOf(status)).formatted(color))
-                    .append(Text.literal(" ]"));
-            var x = txt.getWidth("Logged in as  " + client.getSession().getUsername()) + 3;
-            context.drawText(txt, text, x, 3, 0xFFFFFFFF, true);
+        var txt = client.font;
+        if (METEOR_LOADED && client.screen instanceof JoinMultiplayerScreen) {
+            var text = Component.literal("[ ").append(Component.literal(String.valueOf(status)).withStyle(color))
+                    .append(Component.literal(" ]"));
+            var x = txt.width("Logged in as  " + client.getUser().getName()) + 3;
+            context.text(txt, text, x, 3, 0xFFFFFFFF, true);
             return false;
         } else {
-            var text = status == AuthUtils.AuthStatus.Online ? Text.empty()
-                    .append(Text.literal("Online").formatted(color)).append(" as ")
-                    .append(client.getSession().getUsername()) : Text.literal(String.valueOf(status)).formatted(color);
-            context.drawText(txt, text, 10, 10, 0xFFFFFFFF, true);
+            var text = status == AuthUtils.AuthStatus.Online ? Component.empty()
+                    .append(Component.literal("Online").withStyle(color)).append(" as ")
+                    .append(client.getUser().getName()) : Component.literal(String.valueOf(status)).withStyle(color);
+            context.text(txt, text, 10, 10, 0xFFFFFFFF, true);
 
-            var bounds = new Rect2i(10, 10, txt.getWidth(text), txt.fontHeight);
+            var bounds = new Rect2i(10, 10, txt.width(text), txt.lineHeight);
             var inBounds = bounds.contains(mouseX, mouseY);
-            if (inBounds) context.setCursor(StandardCursors.POINTING_HAND);
+            if (inBounds) context.requestCursor(CursorTypes.POINTING_HAND);
             return inBounds;
         }
     }
@@ -58,7 +57,7 @@ public class Reauth {
         var status = authStatus.getNow(AuthUtils.AuthStatus.Unknown);
         if (config.auto && status.isInvalid() && !sentToast) {
             sentToast = true;
-            var account = config.getAccount(client.session.getUuidOrNull());
+            var account = config.getAccount(client.user.getProfileId());
             if (account.isEmpty()) {
                 Misc.sendToast("AutoReauth", "Session expired but no login info found");
                 return;
@@ -81,10 +80,10 @@ public class Reauth {
                 log.error("Error re-authenticating", e);
             }
             authStatus = AuthUtils.getAuthStatus();
-            Misc.sendToast("AutoReauth", String.format("Authenticated as %s!", session.getUsername()));
+            Misc.sendToast("AutoReauth", String.format("Authenticated as %s!", session.getName()));
         }).exceptionally(e -> {
             log.error("Error re-authenticating", e);
-            client.send(() -> client.setScreen(new ErrorScreen(parent, "Error re-authenticating", e.toString())));
+            client.schedule(() -> client.setScreen(new ErrorScreen(parent, "Error re-authenticating", e.toString())));
             return null;
         });
     }

--- a/src/main/java/com/connorcode/autoreauth/auth/AuthUtils.java
+++ b/src/main/java/com/connorcode/autoreauth/auth/AuthUtils.java
@@ -3,24 +3,23 @@ package com.connorcode.autoreauth.auth;
 import com.mojang.authlib.exceptions.AuthenticationException;
 import com.mojang.authlib.yggdrasil.YggdrasilAuthenticationService;
 import com.mojang.authlib.yggdrasil.YggdrasilMinecraftSessionService;
-import net.minecraft.client.QuickPlay;
-import net.minecraft.client.QuickPlayLogger;
-import net.minecraft.client.gui.screen.TitleScreen;
-import net.minecraft.client.gui.screen.multiplayer.ConnectScreen;
-import net.minecraft.client.network.ServerAddress;
-import net.minecraft.client.network.ServerInfo;
-import net.minecraft.client.network.SocialInteractionsManager;
-import net.minecraft.client.realms.RealmsAvailability;
-import net.minecraft.client.realms.RealmsClient;
-import net.minecraft.client.realms.RealmsPeriodicCheckers;
-import net.minecraft.client.session.ProfileKeys;
-import net.minecraft.client.session.Session;
-import net.minecraft.client.session.report.AbuseReportContext;
-import net.minecraft.client.session.report.ReporterEnvironment;
-import net.minecraft.screen.ScreenTexts;
-
+import com.mojang.realmsclient.RealmsAvailability;
+import com.mojang.realmsclient.client.RealmsClient;
+import com.mojang.realmsclient.gui.RealmsDataFetcher;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import net.minecraft.client.User;
+import net.minecraft.client.gui.screens.ConnectScreen;
+import net.minecraft.client.gui.screens.TitleScreen;
+import net.minecraft.client.gui.screens.social.PlayerSocialManager;
+import net.minecraft.client.multiplayer.ProfileKeyPairManager;
+import net.minecraft.client.multiplayer.ServerData;
+import net.minecraft.client.multiplayer.chat.report.ReportEnvironment;
+import net.minecraft.client.multiplayer.chat.report.ReportingContext;
+import net.minecraft.client.multiplayer.resolver.ServerAddress;
+import net.minecraft.client.quickplay.QuickPlay;
+import net.minecraft.client.quickplay.QuickPlayLog;
+import net.minecraft.network.chat.CommonComponents;
 
 import static com.connorcode.autoreauth.Main.*;
 
@@ -29,15 +28,15 @@ public class AuthUtils {
     public static CompletableFuture<AuthStatus> getAuthStatus() {
         log.info("Checking auth status");
         return CompletableFuture.supplyAsync(() -> {
-            var session = client.getSession();
+            var session = client.getUser();
             var token = session.getAccessToken();
             var id = UUID.randomUUID().toString();
 
             // Thank you https://github.com/axieum/authme
-            var sessionService = (YggdrasilMinecraftSessionService) client.getApiServices().sessionService();
+            var sessionService = (YggdrasilMinecraftSessionService) client.services().sessionService();
             try {
-                sessionService.joinServer(client.getSession().getUuidOrNull(), token, id);
-                var authStatus = sessionService.hasJoinedServer(session.getUsername(), id, null) != null ? AuthStatus.Online : AuthStatus.Offline;
+                sessionService.joinServer(client.getUser().getProfileId(), token, id);
+                var authStatus = sessionService.hasJoinedServer(session.getName(), id, null) != null ? AuthStatus.Online : AuthStatus.Offline;
                 if (authStatus.isOnline()) sentToast = false;
                 log.info("Auth status: " + authStatus.getText());
                 return authStatus;
@@ -48,28 +47,28 @@ public class AuthUtils {
         });
     }
 
-    public static void setSession(Session session) throws AuthenticationException {
-        log.info("Overwriting session with {} ({})", session.getUsername(), session.getUuidOrNull());
-        client.session = session;
-        client.splashTextLoader.session = session;
-        YggdrasilAuthenticationService yggdrasilAuthenticationService = client.isOfflineDeveloperMode() ? YggdrasilAuthenticationService.createOffline(client.getNetworkProxy()) : new YggdrasilAuthenticationService(client.getNetworkProxy());
+    public static void setSession(User session) throws AuthenticationException {
+        log.info("Overwriting session with {} ({})", session.getName(), session.getProfileId());
+        client.user = session;
+        client.splashManager.user = session;
+        YggdrasilAuthenticationService yggdrasilAuthenticationService = client.isOfflineDeveloperMode() ? YggdrasilAuthenticationService.createOffline(client.getProxy()) : new YggdrasilAuthenticationService(client.getProxy());
         client.userApiService = yggdrasilAuthenticationService.createUserApiService(session.getAccessToken());
-        client.socialInteractionsManager = new SocialInteractionsManager(client, client.userApiService);
-        client.profileKeys = ProfileKeys.create(client.userApiService, session, client.runDirectory.toPath());
-        client.abuseReportContext = AbuseReportContext.create(client.abuseReportContext.environment, client.userApiService);
-        RealmsAvailability.currentFuture = null;
+        client.playerSocialManager = new PlayerSocialManager(client, client.userApiService);
+        client.profileKeyPairManager = ProfileKeyPairManager.create(client.userApiService, session, client.gameDirectory.toPath());
+        client.reportingContext = ReportingContext.create(client.reportingContext.environment, client.userApiService);
+        RealmsAvailability.future = null;
 
-        var realmsClient = new RealmsClient(session.getSessionId(), session.getUsername(), client);
-        RealmsClient.instance = realmsClient;
-        client.realmsPeriodicCheckers = new RealmsPeriodicCheckers(realmsClient);
+        var realmsClient = new RealmsClient(session.getSessionId(), session.getName(), client);
+        RealmsClient.realmsClientInstance = realmsClient;
+        client.realmsDataFetcher = new RealmsDataFetcher(realmsClient);
     }
 
-    public static void connectToServer(ServerAddress address, ServerInfo info, boolean quickPlay) {
-        var connectScreen = new ConnectScreen(new TitleScreen(), quickPlay ? QuickPlay.ERROR_TITLE : ScreenTexts.CONNECT_FAILED);
+    public static void connectToServer(ServerAddress address, ServerData info, boolean quickPlay) {
+        var connectScreen = new ConnectScreen(new TitleScreen(), quickPlay ? QuickPlay.ERROR_TITLE : CommonComponents.CONNECT_FAILED);
         client.disconnect(connectScreen, false);
-        client.loadBlockList();
-        client.ensureAbuseReportContext(ReporterEnvironment.ofThirdPartyServer(info != null ? info.address : address.getAddress()));
-        client.getQuickPlayLogger().setWorld(QuickPlayLogger.WorldType.MULTIPLAYER, info.address, info.name);
+        client.prepareForMultiplayer();
+        client.updateReportEnvironment(ReportEnvironment.thirdParty(info != null ? info.ip : address.getHost()));
+        client.quickPlayLog().setWorldData(QuickPlayLog.Type.MULTIPLAYER, info.ip, info.name);
         client.setScreen(connectScreen);
         connectScreen.connect(client, address, info, null);
     }

--- a/src/main/java/com/connorcode/autoreauth/auth/MicrosoftAuth.java
+++ b/src/main/java/com/connorcode/autoreauth/auth/MicrosoftAuth.java
@@ -6,8 +6,8 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.sun.net.httpserver.HttpServer;
-import net.minecraft.client.session.Session;
-import net.minecraft.util.JsonHelper;
+import net.minecraft.client.User;
+import net.minecraft.util.GsonHelper;
 import net.minecraft.util.Util;
 import org.jetbrains.annotations.Nullable;
 
@@ -97,9 +97,9 @@ public class MicrosoftAuth {
             var uri = builder.build();
 
             server.start();
-            Util.getOperatingSystem().open(uri);
+            Util.getPlatform().openUri(uri);
 
-            client.send(() -> client.setScreen(new WaitingForLogin(client.currentScreen, semaphore, uri)));
+            client.schedule(() -> client.setScreen(new WaitingForLogin(client.screen, semaphore, uri)));
 
             try {
                 semaphore.acquire();
@@ -119,13 +119,13 @@ public class MicrosoftAuth {
         if (config.debug) log.info(fmt, args);
     }
 
-    public static CompletableFuture<Session> authenticate(String code) {
+    public static CompletableFuture<User> authenticate(String code) {
         return getAccessToken(code).thenCompose(MicrosoftAuth::authenticateXbox)
                 .thenCompose(MicrosoftAuth::obtainXstsToken).thenCompose(MicrosoftAuth::authenticateMinecraft)
                 .thenCompose(MicrosoftAuth::createSession);
     }
 
-    public static CompletableFuture<Session> authenticate(AccessToken token) {
+    public static CompletableFuture<User> authenticate(AccessToken token) {
         // TODO: Use access token if its still valid
         return refreshAccessToken(token.refreshToken).thenCompose(MicrosoftAuth::authenticateXbox)
                 .thenCompose(MicrosoftAuth::obtainXstsToken).thenCompose(MicrosoftAuth::authenticateMinecraft)
@@ -144,7 +144,7 @@ public class MicrosoftAuth {
                 var str = result.body();
 
                 debugLog("Access token response: {}", str);
-                var json = JsonHelper.deserialize(str);
+                var json = GsonHelper.parse(str);
 
                 var ctx = "access token response from code";
                 var access_token = getIfPresent(json, "access_token", ctx).getAsString();
@@ -167,7 +167,7 @@ public class MicrosoftAuth {
                 var str = client.send(req, HttpResponse.BodyHandlers.ofString()).body();
 
                 debugLog("Refresh token response: {}", str);
-                var json = JsonHelper.deserialize(str);
+                var json = GsonHelper.parse(str);
 
                 var ctx = "access token response from refresh token";
                 var access_token = getIfPresent(json, "access_token", ctx).getAsString();
@@ -197,7 +197,7 @@ public class MicrosoftAuth {
                 var str = client.send(req, HttpResponse.BodyHandlers.ofString()).body();
 
                 debugLog("Xbox auth response: {}", str);
-                var json = JsonHelper.deserialize(str);
+                var json = GsonHelper.parse(str);
 
                 var ctx = "xbox auth response";
                 var xbl_token = getIfPresent(json, "Token", ctx).getAsString();
@@ -229,7 +229,7 @@ public class MicrosoftAuth {
                 var str = client.send(req, HttpResponse.BodyHandlers.ofString()).body();
 
                 debugLog("XSTS auth response: {}", str);
-                var json = JsonHelper.deserialize(str);
+                var json = GsonHelper.parse(str);
 
                 var ctx = "xsts auth response";
                 var xsts_token = getIfPresent(json, "Token", ctx).getAsString();
@@ -252,7 +252,7 @@ public class MicrosoftAuth {
                 var str = client.send(req, HttpResponse.BodyHandlers.ofString()).body();
 
                 debugLog("Minecraft auth response: {}", str);
-                var json = JsonHelper.deserialize(str);
+                var json = GsonHelper.parse(str);
 
                 var ctx = "minecraft auth response";
                 var access_token = getIfPresent(json, "access_token", ctx).getAsString();
@@ -263,7 +263,7 @@ public class MicrosoftAuth {
         });
     }
 
-    static CompletableFuture<Session> createSession(MinecraftAuth minecraftAuth) {
+    static CompletableFuture<User> createSession(MinecraftAuth minecraftAuth) {
         log.info("Creating session");
         return CompletableFuture.supplyAsync(() -> {
             try (var client = HttpClient.newHttpClient()) {
@@ -272,13 +272,13 @@ public class MicrosoftAuth {
                 var str = client.send(req, HttpResponse.BodyHandlers.ofString()).body();
 
                 debugLog("Profile response: {}", str);
-                var json = JsonHelper.deserialize(str);
+                var json = GsonHelper.parse(str);
 
                 var ctx = "profile response";
                 var id = getIfPresent(json, "id", ctx).getAsString();
                 var name = getIfPresent(json, "name", ctx).getAsString();
 
-                return new Session(name, Misc.parseUUID(id), minecraftAuth.accessToken, Optional.empty(), Optional.empty());
+                return new User(name, Misc.parseUUID(id), minecraftAuth.accessToken, Optional.empty(), Optional.empty());
             } catch (IOException | InterruptedException e) {
                 throw new AuthException("Failed to create session", e);
             }

--- a/src/main/java/com/connorcode/autoreauth/auth/NetworkUtils.java
+++ b/src/main/java/com/connorcode/autoreauth/auth/NetworkUtils.java
@@ -1,7 +1,5 @@
 package com.connorcode.autoreauth.auth;
 
-import net.minecraft.util.Pair;
-
 import java.net.URI;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
@@ -11,6 +9,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import net.minecraft.util.Tuple;
 
 public class NetworkUtils {
     public static String urlEncode(String str) {
@@ -48,14 +47,14 @@ public class NetworkUtils {
 
     public static class URIBuilder {
         String base;
-        List<Pair<String, String>> query = new ArrayList<>();
+        List<Tuple<String, String>> query = new ArrayList<>();
 
         public URIBuilder(String base) {
             this.base = base;
         }
 
         public void addParameter(String key, String value) {
-            this.query.add(new Pair<>(key, value));
+            this.query.add(new Tuple<>(key, value));
         }
 
         public URI build() {
@@ -65,9 +64,9 @@ public class NetworkUtils {
             for (int i = 0; i < this.query.size(); i++) {
                 if (i != 0) builder.append("&");
                 var param = this.query.get(i);
-                builder.append(urlEncode(param.getLeft()));
+                builder.append(urlEncode(param.getA()));
                 builder.append("=");
-                builder.append(urlEncode(param.getRight()));
+                builder.append(urlEncode(param.getB()));
             }
 
             return URI.create(builder.toString());

--- a/src/main/java/com/connorcode/autoreauth/gui/ConfigScreen.java
+++ b/src/main/java/com/connorcode/autoreauth/gui/ConfigScreen.java
@@ -5,69 +5,69 @@ import com.connorcode.autoreauth.Main;
 import com.connorcode.autoreauth.Reauth;
 import com.connorcode.autoreauth.auth.AuthUtils;
 import com.connorcode.autoreauth.auth.MicrosoftAuth;
-import net.minecraft.client.gui.DrawContext;
-import net.minecraft.client.gui.PlayerSkinDrawer;
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.gui.tooltip.Tooltip;
-import net.minecraft.client.gui.widget.AlwaysSelectedEntryListWidget;
-import net.minecraft.client.gui.widget.ButtonWidget;
-import net.minecraft.client.gui.widget.DirectionalLayoutWidget;
-import net.minecraft.client.gui.widget.ThreePartsLayoutWidget;
-import net.minecraft.component.type.ProfileComponent;
-import net.minecraft.text.Text;
-import net.minecraft.util.Formatting;
-import net.minecraft.util.Pair;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Semaphore;
 import java.util.function.Function;
+import net.minecraft.ChatFormatting;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.ObjectSelectionList;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.components.PlayerFaceExtractor;
+import net.minecraft.client.gui.components.Tooltip;
+import net.minecraft.client.gui.layouts.HeaderAndFooterLayout;
+import net.minecraft.client.gui.layouts.LinearLayout;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
+import net.minecraft.util.Tuple;
+import net.minecraft.world.item.component.ResolvableProfile;
 
 import static com.connorcode.autoreauth.Main.*;
 
 public class ConfigScreen extends Screen {
-    final ThreePartsLayoutWidget layout = new ThreePartsLayoutWidget(this, 33, 60);
+    final HeaderAndFooterLayout layout = new HeaderAndFooterLayout(this, 33, 60);
     AccountListWidget accountList;
 
-    ButtonWidget switchButton;
-    ButtonWidget deleteButton;
-    ButtonWidget makeDefaultButton;
+    Button switchButton;
+    Button deleteButton;
+    Button makeDefaultButton;
 
     Screen parent;
     Semaphore semaphore = new Semaphore(0);
     CompletableFuture<Void> reauth;
 
     public ConfigScreen(Screen screen) {
-        super(Text.of("AutoReauth Config"));
+        super(Component.nullToEmpty("AutoReauth Config"));
         this.parent = screen;
     }
 
     @Override
     protected void init() {
-        this.layout.addHeader(Text.of("AutoReauth Config"), this.textRenderer);
+        this.layout.addTitleHeader(Component.nullToEmpty("AutoReauth Config"), this.font);
 
-        var footer = this.layout.addFooter(DirectionalLayoutWidget.vertical().spacing(4));
-        footer.getMainPositioner().alignHorizontalCenter();
-        var footerTop = footer.add(DirectionalLayoutWidget.horizontal().spacing(4));
-        var footerBottom = footer.add(DirectionalLayoutWidget.horizontal().spacing(4));
+        var footer = this.layout.addToFooter(LinearLayout.vertical().spacing(4));
+        footer.defaultCellSetting().alignHorizontallyCenter();
+        var footerTop = footer.addChild(LinearLayout.horizontal().spacing(4));
+        var footerBottom = footer.addChild(LinearLayout.horizontal().spacing(4));
 
-        this.switchButton = footerTop.add(ButtonWidget.builder(Text.of("Switch"), (button) -> {
-            var selected = this.accountList.getSelectedOrNull();
+        this.switchButton = footerTop.addChild(Button.builder(Component.nullToEmpty("Switch"), (button) -> {
+            var selected = this.accountList.getSelected();
             if (selected != null) this.reauth = Reauth.attemptReauth(this, selected.account);
         }).width(74).build());
-        this.deleteButton = footerTop.add(ButtonWidget.builder(Text.of("Delete"), (button) -> {
-            var selected = this.accountList.getSelectedOrNull();
+        this.deleteButton = footerTop.addChild(Button.builder(Component.nullToEmpty("Delete"), (button) -> {
+            var selected = this.accountList.getSelected();
             if (selected != null) config.removeAccount(selected.account);
         }).width(74).build());
-        this.makeDefaultButton = footerTop.add(ButtonWidget.builder(Text.of("Make Default"), (button) -> {
-            var selected = this.accountList.getSelectedOrNull();
+        this.makeDefaultButton = footerTop.addChild(Button.builder(Component.nullToEmpty("Make Default"), (button) -> {
+            var selected = this.accountList.getSelected();
             if (selected != null) config.defaultAccount = selected.account;
         }).width(74).build());
-        footerTop.add(ButtonWidget.builder(Text.of("Add Account"), (button) -> MicrosoftAuth.getCode(semaphore)
+        footerTop.addChild(Button.builder(Component.nullToEmpty("Add Account"), (button) -> MicrosoftAuth.getCode(semaphore)
                 .thenCompose(MicrosoftAuth::getAccessToken).thenCompose(access -> MicrosoftAuth.authenticate(access)
-                        .thenApply(session -> new Pair<>(access, session))).thenAccept(pair -> {
-                    config.addAccount(new Config.Account(pair.getLeft(), pair.getRight()));
+                        .thenApply(session -> new Tuple<>(access, session))).thenAccept(pair -> {
+                    config.addAccount(new Config.Account(pair.getA(), pair.getB()));
                     config.save();
 
                     authStatus = AuthUtils.getAuthStatus();
@@ -78,71 +78,71 @@ public class ConfigScreen extends Screen {
                     log.error("Error re-authenticating", e);
                     Main.client.setScreen(new ErrorScreen(this, "Error re-authenticating", e.toString()));
                     return null;
-                })).width(74).tooltip(Tooltip.of(Text.of("Warning: Tokens are stored in your home folder."))).build());
+                })).width(74).tooltip(Tooltip.create(Component.nullToEmpty("Warning: Tokens are stored in your home folder."))).build());
 
 
-        footerBottom.add(callbackButton(clicked -> {
+        footerBottom.addChild(callbackButton(clicked -> {
             config.debug ^= clicked;
             return "Debug: " + (config.debug ? "On" : "Off");
-        }).width(100).tooltip(Tooltip.of(Text.of("Warning: Debug mode will send authentication tokens in the log.")))
+        }).width(100).tooltip(Tooltip.create(Component.nullToEmpty("Warning: Debug mode will send authentication tokens in the log.")))
                 .build());
-        footerBottom.add(callbackButton(clicked -> {
+        footerBottom.addChild(callbackButton(clicked -> {
             config.auto ^= clicked;
             return "Reauth: " + (config.auto ? "Auto" : "Manual");
         }).width(100)
-                .tooltip(Tooltip.of(Text.of("Whether your session should be automatically re-authenticated on expiration.")))
+                .tooltip(Tooltip.create(Component.nullToEmpty("Whether your session should be automatically re-authenticated on expiration.")))
                 .build());
-        footerBottom.add(ButtonWidget.builder(Text.of("Back"), (button) -> {
+        footerBottom.addChild(Button.builder(Component.nullToEmpty("Back"), (button) -> {
             config.save();
             Main.client.setScreen(this.parent);
         }).width(100).build());
 
-        this.accountList = this.layout.addBody(new AccountListWidget(this.width, this.layout.getContentHeight(), this.layout.getHeaderHeight(), 32));
-        this.layout.forEachChild(this::addDrawableChild);
-        this.refreshWidgetPositions();
+        this.accountList = this.layout.addToContents(new AccountListWidget(this.width, this.layout.getContentHeight(), this.layout.getHeaderHeight(), 32));
+        this.layout.visitWidgets(this::addRenderableWidget);
+        this.repositionElements();
     }
 
     @Override
-    protected void refreshWidgetPositions() {
-        this.layout.refreshPositions();
-        this.accountList.position(this.width, this.layout);
+    protected void repositionElements() {
+        this.layout.arrangeElements();
+        this.accountList.updateSize(this.width, this.layout);
     }
 
     @Override
-    public void close() {
+    public void onClose() {
         semaphore.release();
         Main.client.setScreen(this.parent);
     }
 
     @Override
-    public void render(DrawContext context, int mouseX, int mouseY, float delta) {
-        var selected = this.accountList.getSelectedOrNull();
+    public void extractRenderState(GuiGraphicsExtractor context, int mouseX, int mouseY, float delta) {
+        var selected = this.accountList.getSelected();
         var uuid = Optional.ofNullable(selected).map(x -> x.account.uuid());
 
-        this.switchButton.active = (reauth == null || reauth.isDone()) && uuid.isPresent() && !Main.client.session.getUuidOrNull()
+        this.switchButton.active = (reauth == null || reauth.isDone()) && uuid.isPresent() && !Main.client.user.getProfileId()
                 .equals(uuid.get());
         this.makeDefaultButton.active = uuid.isPresent() && !config.isDefault(selected.account);
         this.deleteButton.active = uuid.isPresent();
 
         // ↓ eh prob shouldn't call this every frame but like whatever...
         this.accountList.refreshEntries();
-        super.render(context, mouseX, mouseY, delta);
+        super.extractRenderState(context, mouseX, mouseY, delta);
     }
 
-    private ButtonWidget.Builder callbackButton(Function<Boolean, String> callback) {
-        return ButtonWidget.builder(Text.of(callback.apply(false)), (button) -> {
-            button.setMessage(Text.of(callback.apply(true)));
+    private Button.Builder callbackButton(Function<Boolean, String> callback) {
+        return Button.builder(Component.nullToEmpty(callback.apply(false)), (button) -> {
+            button.setMessage(Component.nullToEmpty(callback.apply(true)));
         });
     }
 
-    class AccountListWidget extends AlwaysSelectedEntryListWidget<AccountListEntry> {
+    class AccountListWidget extends ObjectSelectionList<AccountListEntry> {
         public AccountListWidget(int width, int height, int y, int itemHeight) {
             super(Main.client, width, height, y, itemHeight);
             this.refreshEntries();
         }
 
         void refreshEntries() {
-            var selected = this.getSelectedOrNull();
+            var selected = this.getSelected();
             this.clearEntries();
             for (var account : config.accounts)
                 this.addEntry(new AccountListEntry(account));
@@ -161,7 +161,7 @@ public class ConfigScreen extends Screen {
         @Override
         public void setSelected(@Nullable ConfigScreen.AccountListEntry entry) {
             super.setSelected(entry);
-            ConfigScreen.this.refreshWidgetPositions();
+            ConfigScreen.this.repositionElements();
         }
     }
 
@@ -173,27 +173,27 @@ public class ConfigScreen extends Screen {
         }
 
         @Override
-        public Text getNarration() {
-            return Text.literal(String.format("Account for %s", this.account.username()));
+        public Component getNarration() {
+            return Component.literal(String.format("Account for %s", this.account.username()));
         }
 
         @Override
-        public void render(DrawContext context, int mouseX, int mouseY, boolean hovered, float deltaTicks) {
-            assert client != null;
-            var skin = client.getPlayerSkinCache().get(ProfileComponent.ofDynamic(this.account.uuid())).getTextures();
-            PlayerSkinDrawer.draw(context, skin, this.getContentX(), this.getContentY(), this.getHeight() - 4);
+        public void extractContent(GuiGraphicsExtractor context, int mouseX, int mouseY, boolean hovered, float deltaTicks) {
+            assert minecraft != null;
+            var skin = minecraft.playerSkinRenderCache().getOrDefault(ResolvableProfile.createUnresolved(this.account.uuid())).playerSkin();
+            PlayerFaceExtractor.extractRenderState(context, skin, this.getContentX(), this.getContentY(), this.getHeight() - 4);
 
-            var txt = client.textRenderer;
+            var txt = minecraft.font;
             var contentX = this.getContentX() + this.getHeight();
-            context.drawText(txt, this.account.username(), contentX, this.getContentY() + 2, 0xFFFFFFFF, true);
-            context.drawText(txt, Text.literal(this.account.uuid().toString())
-                    .formatted(Formatting.GRAY), contentX, this.getContentY() + 2 + txt.fontHeight + txt.fontHeight / 3, 0xFFFFFFFF, true);
+            context.text(txt, this.account.username(), contentX, this.getContentY() + 2, 0xFFFFFFFF, true);
+            context.text(txt, Component.literal(this.account.uuid().toString())
+                    .withStyle(ChatFormatting.GRAY), contentX, this.getContentY() + 2 + txt.lineHeight + txt.lineHeight / 3, 0xFFFFFFFF, true);
 
-            var text = Text.empty();
-            if (config.isDefault(account)) text.append(Text.literal("[DEFAULT]").formatted(Formatting.GOLD));
-            if (client.session.getUuidOrNull().equals(account.uuid()))
-                text.append(Text.literal(" [ACTIVE]").formatted(Formatting.GREEN));
-            context.drawText(txt, text, this.getContentX() + this.getContentWidth() - txt.getWidth(text), this.getContentY() + 2, 0xFFFFFFFF, true);
+            var text = Component.empty();
+            if (config.isDefault(account)) text.append(Component.literal("[DEFAULT]").withStyle(ChatFormatting.GOLD));
+            if (minecraft.user.getProfileId().equals(account.uuid()))
+                text.append(Component.literal(" [ACTIVE]").withStyle(ChatFormatting.GREEN));
+            context.text(txt, text, this.getContentX() + this.getContentWidth() - txt.width(text), this.getContentY() + 2, 0xFFFFFFFF, true);
         }
     }
 }

--- a/src/main/java/com/connorcode/autoreauth/gui/ErrorScreen.java
+++ b/src/main/java/com/connorcode/autoreauth/gui/ErrorScreen.java
@@ -1,12 +1,12 @@
 package com.connorcode.autoreauth.gui;
 
 import com.connorcode.autoreauth.Main;
-import net.minecraft.client.gui.DrawContext;
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.gui.widget.ButtonWidget;
-import net.minecraft.text.StringVisitable;
-import net.minecraft.text.Style;
-import net.minecraft.text.Text;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.FormattedText;
+import net.minecraft.network.chat.Style;
 
 public class ErrorScreen extends Screen {
     Screen parent;
@@ -14,7 +14,7 @@ public class ErrorScreen extends Screen {
     String error;
 
     public ErrorScreen(Screen parent, String title, String error) {
-        super(Text.of("Error"));
+        super(Component.nullToEmpty("Error"));
         this.parent = parent;
         this.title = title;
         this.error = error;
@@ -22,31 +22,31 @@ public class ErrorScreen extends Screen {
 
     @Override
     protected void init() {
-        addDrawableChild(ButtonWidget.builder(Text.of("Back"), (button) -> {
+        addRenderableWidget(Button.builder(Component.nullToEmpty("Back"), (button) -> {
             Main.client.setScreen(parent);
-        }).size(200, 20).position(this.width / 2 - 100, this.height - 30).build());
+        }).size(200, 20).pos(this.width / 2 - 100, this.height - 30).build());
     }
 
     @Override
-    public void close() {
+    public void onClose() {
         Main.client.setScreen(parent);
     }
 
     @Override
-    public void render(DrawContext context, int mouseX, int mouseY, float delta) {
-        super.render(context, mouseX, mouseY, delta);
+    public void extractRenderState(GuiGraphicsExtractor context, int mouseX, int mouseY, float delta) {
+        super.extractRenderState(context, mouseX, mouseY, delta);
 
-        var txt = Main.client.textRenderer;
+        var txt = Main.client.font;
 
-        var title = Text.of(this.title).getWithStyle(Style.EMPTY.withBold(true)).get(0);
-        var titleWidth = txt.getWidth(title);
-        context.drawText(txt, title, this.width / 2 - titleWidth / 2, 20, 0xFFFFFFFF, true);
+        var title = Component.nullToEmpty(this.title).toFlatList(Style.EMPTY.withBold(true)).get(0);
+        var titleWidth = txt.width(title);
+        context.text(txt, title, this.width / 2 - titleWidth / 2, 20, 0xFFFFFFFF, true);
 
-        var lines = txt.wrapLines(StringVisitable.plain(this.error), 300);
+        var lines = txt.split(FormattedText.of(this.error), 300);
         for (var i = 0; i < lines.size(); i++) {
             var line = lines.get(i);
-            var lineWidth = txt.getWidth(line);
-            context.drawText(txt, line, this.width / 2 - lineWidth / 2, 40 + i * 10, 0xFFFFFFFF, true);
+            var lineWidth = txt.width(line);
+            context.text(txt, line, this.width / 2 - lineWidth / 2, 40 + i * 10, 0xFFFFFFFF, true);
         }
     }
 }

--- a/src/main/java/com/connorcode/autoreauth/gui/RealmsWaitingScreen.java
+++ b/src/main/java/com/connorcode/autoreauth/gui/RealmsWaitingScreen.java
@@ -2,16 +2,16 @@ package com.connorcode.autoreauth.gui;
 
 import com.connorcode.autoreauth.Main;
 import com.connorcode.autoreauth.auth.AuthUtils;
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.realms.gui.screen.RealmsMainScreen;
-import net.minecraft.text.Text;
+import com.mojang.realmsclient.RealmsMainScreen;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
 
 import static com.connorcode.autoreauth.Main.authStatus;
 import static com.connorcode.autoreauth.Reauth.tickAuthStatus;
 
 public class RealmsWaitingScreen extends WaitingScreen {
     public RealmsWaitingScreen(Screen parent) {
-        super(parent, Text.literal("You will automatically continue to Realms once you are authenticated."));
+        super(parent, Component.literal("You will automatically continue to Realms once you are authenticated."));
         this.parent = parent;
     }
 

--- a/src/main/java/com/connorcode/autoreauth/gui/ServerWaitingScreen.java
+++ b/src/main/java/com/connorcode/autoreauth/gui/ServerWaitingScreen.java
@@ -1,21 +1,21 @@
 package com.connorcode.autoreauth.gui;
 
 import com.connorcode.autoreauth.auth.AuthUtils;
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.network.ServerAddress;
-import net.minecraft.client.network.ServerInfo;
-import net.minecraft.text.Text;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.multiplayer.ServerData;
+import net.minecraft.client.multiplayer.resolver.ServerAddress;
+import net.minecraft.network.chat.Component;
 
 import static com.connorcode.autoreauth.Main.authStatus;
 import static com.connorcode.autoreauth.Reauth.tickAuthStatus;
 
 public class ServerWaitingScreen extends WaitingScreen {
     ServerAddress address;
-    ServerInfo info;
+    ServerData info;
     boolean quickPlay;
 
-    public ServerWaitingScreen(Screen parent, ServerAddress address, ServerInfo info, boolean quickPlay) {
-        super(parent, Text.literal("You will automatically join the server once you are authenticated."));
+    public ServerWaitingScreen(Screen parent, ServerAddress address, ServerData info, boolean quickPlay) {
+        super(parent, Component.literal("You will automatically join the server once you are authenticated."));
         this.parent = parent;
         this.address = address;
         this.info = info;

--- a/src/main/java/com/connorcode/autoreauth/gui/WaitingForLogin.java
+++ b/src/main/java/com/connorcode/autoreauth/gui/WaitingForLogin.java
@@ -1,61 +1,60 @@
 package com.connorcode.autoreauth.gui;
 
 import com.connorcode.autoreauth.Main;
-import net.minecraft.client.gui.DrawContext;
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.gui.widget.ButtonWidget;
-import net.minecraft.client.gui.widget.GridWidget;
-import net.minecraft.client.gui.widget.SimplePositioningWidget;
-import net.minecraft.text.Text;
-import net.minecraft.util.Formatting;
-
 import java.net.URI;
 import java.util.concurrent.Semaphore;
+import net.minecraft.ChatFormatting;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.layouts.FrameLayout;
+import net.minecraft.client.gui.layouts.GridLayout;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
 
 public class WaitingForLogin extends Screen {
-    private static final Text message = Text.literal("Complete the oauth flow opened in your browser. If it failed to open, you can manually copy the link with the button below.");
-    private final GridWidget grid = new GridWidget().setColumnSpacing(5);
+    private static final Component message = Component.literal("Complete the oauth flow opened in your browser. If it failed to open, you can manually copy the link with the button below.");
+    private final GridLayout grid = new GridLayout().columnSpacing(5);
 
     Screen parent;
     Semaphore semaphore;
     URI redirect;
 
     public WaitingForLogin(Screen parent, Semaphore semaphore, URI redirect) {
-        super(Text.of("Waiting for Login"));
+        super(Component.nullToEmpty("Waiting for Login"));
         this.parent = parent;
         this.semaphore = semaphore;
         this.redirect = redirect;
     }
 
     @Override
-    public void close() {
+    public void onClose() {
         semaphore.release();
         Main.client.setScreen(parent);
     }
 
     @Override
     protected void init() {
-        var adder = this.grid.createAdder(2);
-        var positioner = adder.copyPositioner().alignHorizontalCenter();
+        var adder = this.grid.createRowHelper(2);
+        var positioner = adder.newCellSettings().alignHorizontallyCenter();
 
-        adder.add(ButtonWidget.builder(Text.of("Copy Auth Link"), (button) -> Main.client.keyboard.setClipboard(redirect.toString()))
+        adder.addChild(Button.builder(Component.nullToEmpty("Copy Auth Link"), (button) -> Main.client.keyboardHandler.setClipboard(redirect.toString()))
                 .build(), positioner);
-        adder.add(ButtonWidget.builder(Text.of("Abort"), (button) -> this.close()).build(), positioner);
+        adder.addChild(Button.builder(Component.nullToEmpty("Abort"), (button) -> this.onClose()).build(), positioner);
 
-        this.grid.forEachChild(this::addDrawableChild);
-        this.grid.refreshPositions();
-        SimplePositioningWidget.setPos(this.grid, 0, this.height - 64, this.width, 64);
+        this.grid.visitWidgets(this::addRenderableWidget);
+        this.grid.arrangeElements();
+        FrameLayout.centerInRectangle(this.grid, 0, this.height - 64, this.width, 64);
     }
 
     @Override
-    public void render(DrawContext context, int mouseX, int mouseY, float delta) {
+    public void extractRenderState(GuiGraphicsExtractor context, int mouseX, int mouseY, float delta) {
         if (!semaphore.hasQueuedThreads()) Main.client.setScreen(parent);
 
-        super.render(context, mouseX, mouseY, delta);
-        var txt = Main.client.textRenderer;
+        super.extractRenderState(context, mouseX, mouseY, delta);
+        var txt = Main.client.font;
 
-        var title = Text.literal("AutoReauth").formatted(Formatting.BOLD);
-        context.drawCenteredTextWithShadow(txt, title, this.width / 2, 20, 0xFFFFFFFF);
-        context.drawWrappedText(txt, message, this.width / 2 - 256 / 2, 40, 256, 0xFFFFFFFF, true);
+        var title = Component.literal("AutoReauth").withStyle(ChatFormatting.BOLD);
+        context.centeredText(txt, title, this.width / 2, 20, 0xFFFFFFFF);
+        context.textWithWordWrap(txt, message, this.width / 2 - 256 / 2, 40, 256, 0xFFFFFFFF, true);
     }
 }

--- a/src/main/java/com/connorcode/autoreauth/gui/WaitingScreen.java
+++ b/src/main/java/com/connorcode/autoreauth/gui/WaitingScreen.java
@@ -1,33 +1,33 @@
 package com.connorcode.autoreauth.gui;
 
 import com.connorcode.autoreauth.Main;
-import net.minecraft.client.gui.DrawContext;
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.text.Style;
-import net.minecraft.text.Text;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.Style;
 
 public abstract class WaitingScreen extends Screen {
     Screen parent;
-    Text message;
+    Component message;
 
-    protected WaitingScreen(Screen parent, Text message) {
-        super(Text.of("Waiting for Reauth"));
+    protected WaitingScreen(Screen parent, Component message) {
+        super(Component.nullToEmpty("Waiting for Reauth"));
         this.parent = parent;
         this.message = message;
     }
 
     @Override
-    public void close() {
+    public void onClose() {
         Main.client.setScreen(parent);
     }
 
     @Override
-    public void render(DrawContext context, int mouseX, int mouseY, float delta) {
-        super.render(context, mouseX, mouseY, delta);
-        var txt = Main.client.textRenderer;
+    public void extractRenderState(GuiGraphicsExtractor context, int mouseX, int mouseY, float delta) {
+        super.extractRenderState(context, mouseX, mouseY, delta);
+        var txt = Main.client.font;
 
-        var title = Text.literal("AutoReauth").fillStyle(Style.EMPTY.withBold(true));
-        context.drawCenteredTextWithShadow(txt, title, this.width / 2, 20, 0xFFFFFFFF);
-        context.drawCenteredTextWithShadow(txt, message, this.width / 2, this.height / 2 + txt.fontHeight / 2, 0xFFFFFFFF);
+        var title = Component.literal("AutoReauth").withStyle(Style.EMPTY.withBold(true));
+        context.centeredText(txt, title, this.width / 2, 20, 0xFFFFFFFF);
+        context.centeredText(txt, message, this.width / 2, this.height / 2 + txt.lineHeight / 2, 0xFFFFFFFF);
     }
 }

--- a/src/main/java/com/connorcode/autoreauth/mixin/ConnectScreenMixin.java
+++ b/src/main/java/com/connorcode/autoreauth/mixin/ConnectScreenMixin.java
@@ -2,12 +2,12 @@ package com.connorcode.autoreauth.mixin;
 
 import com.connorcode.autoreauth.auth.AuthUtils;
 import com.connorcode.autoreauth.gui.ServerWaitingScreen;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.gui.screen.multiplayer.ConnectScreen;
-import net.minecraft.client.network.CookieStorage;
-import net.minecraft.client.network.ServerAddress;
-import net.minecraft.client.network.ServerInfo;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.ConnectScreen;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.multiplayer.ServerData;
+import net.minecraft.client.multiplayer.TransferState;
+import net.minecraft.client.multiplayer.resolver.ServerAddress;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -19,10 +19,10 @@ import static com.connorcode.autoreauth.Main.config;
 
 @Mixin(ConnectScreen.class)
 public class ConnectScreenMixin {
-    @Inject(method = "connect(Lnet/minecraft/client/gui/screen/Screen;Lnet/minecraft/client/MinecraftClient;Lnet/minecraft/client/network/ServerAddress;Lnet/minecraft/client/network/ServerInfo;ZLnet/minecraft/client/network/CookieStorage;)V", at = @At("HEAD"), cancellable = true)
-    private static void onConnect(Screen screen, MinecraftClient client, ServerAddress address, ServerInfo info, boolean quickPlay, @Nullable CookieStorage cookieStorage, CallbackInfo ci) {
+    @Inject(method = "startConnecting(Lnet/minecraft/client/gui/screens/Screen;Lnet/minecraft/client/Minecraft;Lnet/minecraft/client/multiplayer/resolver/ServerAddress;Lnet/minecraft/client/multiplayer/ServerData;ZLnet/minecraft/client/multiplayer/TransferState;)V", at = @At("HEAD"), cancellable = true)
+    private static void onConnect(Screen screen, Minecraft client, ServerAddress address, ServerData info, boolean quickPlay, @Nullable TransferState cookieStorage, CallbackInfo ci) {
         if (!config.auto || authStatus.getNow(AuthUtils.AuthStatus.Invalid).isOnline()) return;
-        client.setScreen(new ServerWaitingScreen(client.currentScreen, address, info, quickPlay));
+        client.setScreen(new ServerWaitingScreen(client.screen, address, info, quickPlay));
         ci.cancel();
     }
 }

--- a/src/main/java/com/connorcode/autoreauth/mixin/DisconnectedScreenMixin.java
+++ b/src/main/java/com/connorcode/autoreauth/mixin/DisconnectedScreenMixin.java
@@ -1,9 +1,5 @@
 package com.connorcode.autoreauth.mixin;
 
-import net.minecraft.client.gui.DrawContext;
-import net.minecraft.client.gui.screen.DisconnectedScreen;
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.text.Text;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -12,21 +8,26 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import static com.connorcode.autoreauth.Reauth.refreshAuthStatus;
 import static com.connorcode.autoreauth.Reauth.renderAuthStatus;
 
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.screens.DisconnectedScreen;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
+
 @Mixin(DisconnectedScreen.class)
 public class DisconnectedScreenMixin extends Screen {
-    protected DisconnectedScreenMixin(Text title) {
+    protected DisconnectedScreenMixin(Component title) {
         super(title);
         throw new UnsupportedOperationException("Mixin constructor");
     }
 
-    @Inject(at = @At("TAIL"), method = "<init>(Lnet/minecraft/client/gui/screen/Screen;Lnet/minecraft/text/Text;Lnet/minecraft/text/Text;Lnet/minecraft/text/Text;)V")
+    @Inject(at = @At("TAIL"), method = "<init>(Lnet/minecraft/client/gui/screens/Screen;Lnet/minecraft/network/chat/Component;Lnet/minecraft/network/chat/Component;Lnet/minecraft/network/chat/Component;)V")
     void onInit(CallbackInfo ci) {
         refreshAuthStatus();
     }
 
     @Override
-    public void render(DrawContext context, int mouseX, int mouseY, float delta) {
-        super.render(context, mouseX, mouseY, delta);
+    public void extractRenderState(GuiGraphicsExtractor context, int mouseX, int mouseY, float delta) {
+        super.extractRenderState(context, mouseX, mouseY, delta);
         renderAuthStatus(context, mouseX, mouseY);
     }
 

--- a/src/main/java/com/connorcode/autoreauth/mixin/MinecraftClientMixin.java
+++ b/src/main/java/com/connorcode/autoreauth/mixin/MinecraftClientMixin.java
@@ -1,8 +1,5 @@
 package com.connorcode.autoreauth.mixin;
 
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.screen.DisconnectedScreen;
-import net.minecraft.client.gui.screen.Screen;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -12,17 +9,21 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import static com.connorcode.autoreauth.Reauth.tickAuthStatus;
 
-@Mixin(MinecraftClient.class)
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.DisconnectedScreen;
+import net.minecraft.client.gui.screens.Screen;
+
+@Mixin(Minecraft.class)
 public class MinecraftClientMixin {
     @Shadow
     @Nullable
-    public Screen currentScreen;
+    public Screen screen;
 
     @Inject(at = @At("HEAD"), method = "tick")
     void onTick(CallbackInfo ci) {
         // So janky sob but it's needed for meteor client compat
-        if (this.currentScreen instanceof DisconnectedScreen) {
-            tickAuthStatus(this.currentScreen);
+        if (this.screen instanceof DisconnectedScreen) {
+            tickAuthStatus(this.screen);
         }
     }
 }

--- a/src/main/java/com/connorcode/autoreauth/mixin/MultiplayerScreenMixin.java
+++ b/src/main/java/com/connorcode/autoreauth/mixin/MultiplayerScreenMixin.java
@@ -1,11 +1,6 @@
 package com.connorcode.autoreauth.mixin;
 
 import com.connorcode.autoreauth.gui.ConfigScreen;
-import net.minecraft.client.gui.Click;
-import net.minecraft.client.gui.DrawContext;
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.gui.screen.multiplayer.MultiplayerScreen;
-import net.minecraft.text.Text;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -13,15 +8,20 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.Objects;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.gui.screens.multiplayer.JoinMultiplayerScreen;
+import net.minecraft.client.input.MouseButtonEvent;
+import net.minecraft.network.chat.Component;
 
 import static com.connorcode.autoreauth.Reauth.*;
 
-@Mixin(MultiplayerScreen.class)
+@Mixin(JoinMultiplayerScreen.class)
 public class MultiplayerScreenMixin extends Screen {
     @Unique
     boolean hovered;
 
-    protected MultiplayerScreenMixin(Text title) {
+    protected MultiplayerScreenMixin(Component title) {
         super(title);
         throw new UnsupportedOperationException("Mixin constructor");
     }
@@ -32,8 +32,8 @@ public class MultiplayerScreenMixin extends Screen {
     }
 
     @Override
-    public void render(DrawContext context, int mouseX, int mouseY, float delta) {
-        super.render(context, mouseX, mouseY, delta);
+    public void extractRenderState(GuiGraphicsExtractor context, int mouseX, int mouseY, float delta) {
+        super.extractRenderState(context, mouseX, mouseY, delta);
         this.hovered = renderAuthStatus(context, mouseX, mouseY);
     }
 
@@ -43,8 +43,8 @@ public class MultiplayerScreenMixin extends Screen {
     }
 
     @Override
-    public boolean mouseClicked(Click click, boolean doubled) {
-        if (this.hovered) Objects.requireNonNull(client).setScreen(new ConfigScreen(this));
+    public boolean mouseClicked(MouseButtonEvent click, boolean doubled) {
+        if (this.hovered) Objects.requireNonNull(minecraft).setScreen(new ConfigScreen(this));
         return super.mouseClicked(click, doubled);
     }
 }

--- a/src/main/java/com/connorcode/autoreauth/mixin/RealmsMainScreenMixin.java
+++ b/src/main/java/com/connorcode/autoreauth/mixin/RealmsMainScreenMixin.java
@@ -4,13 +4,8 @@ import com.connorcode.autoreauth.Main;
 import com.connorcode.autoreauth.auth.AuthUtils;
 import com.connorcode.autoreauth.gui.ConfigScreen;
 import com.connorcode.autoreauth.gui.RealmsWaitingScreen;
-import net.minecraft.client.gui.Click;
-import net.minecraft.client.gui.DrawContext;
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.gui.screen.TitleScreen;
-import net.minecraft.client.realms.RealmsAvailability;
-import net.minecraft.client.realms.gui.screen.RealmsMainScreen;
-import net.minecraft.text.Text;
+import com.mojang.realmsclient.RealmsAvailability;
+import com.mojang.realmsclient.RealmsMainScreen;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -19,6 +14,11 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.gui.screens.TitleScreen;
+import net.minecraft.client.input.MouseButtonEvent;
+import net.minecraft.network.chat.Component;
 
 import static com.connorcode.autoreauth.Main.*;
 import static com.connorcode.autoreauth.Reauth.*;
@@ -28,7 +28,7 @@ public class RealmsMainScreenMixin extends Screen {
     @Unique
     boolean hovered;
 
-    protected RealmsMainScreenMixin(Text title) {
+    protected RealmsMainScreenMixin(Component title) {
         super(title);
         throw new UnsupportedOperationException("Mixin constructor");
     }
@@ -38,8 +38,8 @@ public class RealmsMainScreenMixin extends Screen {
         refreshAuthStatus();
     }
 
-    @Inject(at = @At("TAIL"), method = "render")
-    private void render(DrawContext context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
+    @Inject(at = @At("TAIL"), method = "extractRenderState")
+    private void render(GuiGraphicsExtractor context, int mouseX, int mouseY, float delta, CallbackInfo ci) {
         this.hovered = renderAuthStatus(context, mouseX, mouseY);
     }
 
@@ -48,8 +48,8 @@ public class RealmsMainScreenMixin extends Screen {
         tickAuthStatus(this);
     }
 
-    @Inject(at = @At("HEAD"), method = "method_52634(Lnet/minecraft/client/realms/RealmsAvailability$Info;)V", cancellable = true)
-    void onRealmsAvailabilityInfo(RealmsAvailability.Info info, CallbackInfo ci) {
+    @Inject(at = @At("HEAD"), method = "lambda$init$9(Lcom/mojang/realmsclient/RealmsAvailability$Result;)V", cancellable = true)
+    void onRealmsAvailabilityInfo(RealmsAvailability.Result info, CallbackInfo ci) {
         if (!config.auto || info.type() != RealmsAvailability.Type.AUTHENTICATION_ERROR) return;
 
         log.info("Invalid Realms auth, re-authenticating...");
@@ -59,8 +59,8 @@ public class RealmsMainScreenMixin extends Screen {
     }
 
     @Override
-    public boolean mouseClicked(Click click, boolean doubled) {
-        if (this.hovered) Objects.requireNonNull(client).setScreen(new ConfigScreen(this));
+    public boolean mouseClicked(MouseButtonEvent click, boolean doubled) {
+        if (this.hovered) Objects.requireNonNull(minecraft).setScreen(new ConfigScreen(this));
         return super.mouseClicked(click, doubled);
     }
 }

--- a/src/main/resources/auto-reauth.accesswidener
+++ b/src/main/resources/auto-reauth.accesswidener
@@ -1,30 +1,24 @@
-accessWidener   v1  named
-
-## AuthUtils::setSession ##
-accessible field net/minecraft/client/MinecraftClient splashTextLoader Lnet/minecraft/client/resource/SplashTextResourceSupplier;
-accessible field net/minecraft/client/MinecraftClient session Lnet/minecraft/client/session/Session;
-accessible field net/minecraft/client/resource/SplashTextResourceSupplier session Lnet/minecraft/client/session/Session;
-accessible field net/minecraft/client/MinecraftClient socialInteractionsManager Lnet/minecraft/client/network/SocialInteractionsManager;
-accessible field net/minecraft/client/MinecraftClient profileKeys Lnet/minecraft/client/session/ProfileKeys;
-accessible field net/minecraft/client/MinecraftClient abuseReportContext Lnet/minecraft/client/session/report/AbuseReportContext;
-accessible field net/minecraft/client/MinecraftClient realmsPeriodicCheckers Lnet/minecraft/client/realms/RealmsPeriodicCheckers;
-accessible field net/minecraft/client/MinecraftClient userApiService Lcom/mojang/authlib/minecraft/UserApiService;
-accessible field net/minecraft/client/session/report/AbuseReportContext environment Lnet/minecraft/client/session/report/ReporterEnvironment;
-accessible field net/minecraft/client/realms/RealmsAvailability currentFuture Ljava/util/concurrent/CompletableFuture;
-accessible field net/minecraft/client/realms/RealmsClient instance Lnet/minecraft/client/realms/RealmsClient;
-
-mutable field net/minecraft/client/MinecraftClient session Lnet/minecraft/client/session/Session;
-mutable field net/minecraft/client/MinecraftClient splashTextLoader Lnet/minecraft/client/resource/SplashTextResourceSupplier;
-mutable field net/minecraft/client/resource/SplashTextResourceSupplier session Lnet/minecraft/client/session/Session;
-mutable field net/minecraft/client/MinecraftClient socialInteractionsManager Lnet/minecraft/client/network/SocialInteractionsManager;
-mutable field net/minecraft/client/MinecraftClient profileKeys Lnet/minecraft/client/session/ProfileKeys;
-mutable field net/minecraft/client/MinecraftClient abuseReportContext Lnet/minecraft/client/session/report/AbuseReportContext;
-mutable field net/minecraft/client/MinecraftClient realmsPeriodicCheckers Lnet/minecraft/client/realms/RealmsPeriodicCheckers;
-mutable field net/minecraft/client/MinecraftClient userApiService Lcom/mojang/authlib/minecraft/UserApiService;
-mutable field net/minecraft/client/realms/RealmsAvailability currentFuture Ljava/util/concurrent/CompletableFuture;
-
-accessible method net/minecraft/client/realms/RealmsClient <init> (Ljava/lang/String;Ljava/lang/String;Lnet/minecraft/client/MinecraftClient;)V
-
-## AuthUtils::connectToServer ##
-accessible method net/minecraft/client/gui/screen/multiplayer/ConnectScreen <init> (Lnet/minecraft/client/gui/screen/Screen;Lnet/minecraft/text/Text;)V
-accessible method net/minecraft/client/gui/screen/multiplayer/ConnectScreen connect (Lnet/minecraft/client/MinecraftClient;Lnet/minecraft/client/network/ServerAddress;Lnet/minecraft/client/network/ServerInfo;Lnet/minecraft/client/network/CookieStorage;)V
+accessWidener	v1	official
+accessible	field	net/minecraft/client/Minecraft	splashManager	Lnet/minecraft/client/resources/SplashManager;
+accessible	field	net/minecraft/client/Minecraft	user	Lnet/minecraft/client/User;
+accessible	field	net/minecraft/client/resources/SplashManager	user	Lnet/minecraft/client/User;
+accessible	field	net/minecraft/client/Minecraft	playerSocialManager	Lnet/minecraft/client/gui/screens/social/PlayerSocialManager;
+accessible	field	net/minecraft/client/Minecraft	profileKeyPairManager	Lnet/minecraft/client/multiplayer/ProfileKeyPairManager;
+accessible	field	net/minecraft/client/Minecraft	reportingContext	Lnet/minecraft/client/multiplayer/chat/report/ReportingContext;
+accessible	field	net/minecraft/client/Minecraft	realmsDataFetcher	Lcom/mojang/realmsclient/gui/RealmsDataFetcher;
+accessible	field	net/minecraft/client/Minecraft	userApiService	Lcom/mojang/authlib/minecraft/UserApiService;
+accessible	field	net/minecraft/client/multiplayer/chat/report/ReportingContext	environment	Lnet/minecraft/client/multiplayer/chat/report/ReportEnvironment;
+accessible	field	com/mojang/realmsclient/RealmsAvailability	future	Ljava/util/concurrent/CompletableFuture;
+accessible	field	com/mojang/realmsclient/client/RealmsClient	realmsClientInstance	Lcom/mojang/realmsclient/client/RealmsClient;
+mutable	field	net/minecraft/client/Minecraft	user	Lnet/minecraft/client/User;
+mutable	field	net/minecraft/client/Minecraft	splashManager	Lnet/minecraft/client/resources/SplashManager;
+mutable	field	net/minecraft/client/resources/SplashManager	user	Lnet/minecraft/client/User;
+mutable	field	net/minecraft/client/Minecraft	playerSocialManager	Lnet/minecraft/client/gui/screens/social/PlayerSocialManager;
+mutable	field	net/minecraft/client/Minecraft	profileKeyPairManager	Lnet/minecraft/client/multiplayer/ProfileKeyPairManager;
+mutable	field	net/minecraft/client/Minecraft	reportingContext	Lnet/minecraft/client/multiplayer/chat/report/ReportingContext;
+mutable	field	net/minecraft/client/Minecraft	realmsDataFetcher	Lcom/mojang/realmsclient/gui/RealmsDataFetcher;
+mutable	field	net/minecraft/client/Minecraft	userApiService	Lcom/mojang/authlib/minecraft/UserApiService;
+mutable	field	com/mojang/realmsclient/RealmsAvailability	future	Ljava/util/concurrent/CompletableFuture;
+accessible	method	com/mojang/realmsclient/client/RealmsClient	<init>	(Ljava/lang/String;Ljava/lang/String;Lnet/minecraft/client/Minecraft;)V
+accessible	method	net/minecraft/client/gui/screens/ConnectScreen	<init>	(Lnet/minecraft/client/gui/screens/Screen;Lnet/minecraft/network/chat/Component;)V
+accessible	method	net/minecraft/client/gui/screens/ConnectScreen	connect	(Lnet/minecraft/client/Minecraft;Lnet/minecraft/client/multiplayer/resolver/ServerAddress;Lnet/minecraft/client/multiplayer/ServerData;Lnet/minecraft/client/multiplayer/TransferState;)V

--- a/src/main/resources/auto-reauth.mixins.json
+++ b/src/main/resources/auto-reauth.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "minVersion": "0.8",
   "package": "com.connorcode.autoreauth.mixin",
-  "compatibilityLevel": "JAVA_17",
+  "compatibilityLevel": "JAVA_25",
   "mixins": [
   ],
   "client": [

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -29,8 +29,8 @@
   "accessWidener": "auto-reauth.accesswidener",
   "depends": {
     "fabricloader": ">=${loader_version}",
-    "fabric": "*",
-    "minecraft": "${minecraft_version}"
+    "fabric-api": "*",
+    "minecraft": ">=${minecraft_version}"
   },
   "custom": {
     "modmenu": {


### PR DESCRIPTION
- Target MC 26.1.2 with Fabric Loader 0.19.2, Fabric API 0.146.1+26.1.2, Loom 1.16
- Gradle 9.4 wrapper; remove Yarn; unobfuscated build (no mappings line)
- Migrate sources/access widener to official namespace; mixin compatibility JAVA_25
- Update UI to GuiGraphicsExtractor and Screen.extractRenderState; ClientCommands
- fabric.mod.json: depend on fabric-api; minecraft >=26.1.2
- Mod Menu 18.0.0-alpha.8; fix RealmsMainScreen mixin for lambda$init$9
- Update ModMenu and related mixins for 26.1 APIs