### PR TITLE
Add delay to refreshAuthStatus method

### DIFF
--- a/src/main/java/com/connorcode/autoreauth/Reauth.java
+++ b/src/main/java/com/connorcode/autoreauth/Reauth.java
@@ -70,7 +70,13 @@ public class Reauth {
     }
 
     public static void refreshAuthStatus() {
-        authStatus = AuthUtils.getAuthStatus();
+//        This method will be called whenever the Multiplayer tab is opened
+//        or the servers are refreshed (as refreshing just secretly reopens the list)
+        var now = System.currentTimeMillis();
+        if (lastUpdate + 1000 * 5 < now) { // Now we check for a 5s delay and I stole this code from line 53
+             lastUpdate = now;
+             authStatus = AuthUtils.getAuthStatus();
+        }
     }
 
     public static CompletableFuture<Void> attemptReauth(Screen parent, Config.Account account) {


### PR DESCRIPTION
Implement a delay in refreshing the authentication status to avoid frequent updates.

Fix #21 (for 1.21.11)